### PR TITLE
PHP 8.2 required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0.0",
+    "php": ">=8.2",
     "pdga/exception": "^1.0"
   },
   "autoload": {


### PR DESCRIPTION
We'll need PHP 8.1 at least to allow `new ConverterInstance()` in the Column attributes. The docker image uses PHP 8.2