### PR TITLE
Bdb/ok 59/ok 60/cardinality

### DIFF
--- a/src/Attributes/Cardinality.php
+++ b/src/Attributes/Cardinality.php
@@ -10,35 +10,34 @@ use Attribute;
 abstract class Cardinality
 {
     /**
-     * Initialize with the two related classes, left and right.  The
-     * cardinality is from left to right, like a RDBMS.
+     * Initialize with a related class, relation.  The cardinality is from left
+     * to right, like a RDBMS, so the class that uses this attribute is like
+     * the left table, and the relation is like the right table.
      *
-     * @param string $left - The left Data Object class.
-     * @param string $right - The right, related Data Object class.
+     * @param string $relation - The right, related Data Object class.
      */
     public function __construct(
-        protected string $left,
-        protected string $right,
+        protected string $relation,
     ) {}
 
-    /**
-     * Get an instance of the left class.
-     *
-     * @return object A Data Object instance.
-     */
-    public function getLeftInstance(): object
+   /**
+    * Get the fully-qualified path of the relation.
+    *
+    * @return string Class path.
+    */
+    public function getRelationClass(): string
     {
-        return new $this->left;
+        return $this->relation;
     }
 
    /**
-    * Get an instance of the right class.
+    * Get an instance of the relation (right) class.
     *
     * @return object A Data Object instance.
     */
-    public function getRightInstance(): object
+    public function getRelationInstance(): object
     {
-        return new $this->right;
+        return new $this->relation;
     }
 
     /**
@@ -46,5 +45,5 @@ abstract class Cardinality
      *
      * @return string
      */
-    abstract public function describe(): string;
+    abstract public function getDescription(): string;
 }

--- a/src/Attributes/Cardinality.php
+++ b/src/Attributes/Cardinality.php
@@ -15,9 +15,12 @@ abstract class Cardinality
      * the left table, and the relation is like the right table.
      *
      * @param string $relation - The right, related Data Object class.
+     * @param string $alias    - In query results, this is the name of the
+     * property where the related data are set.
      */
     public function __construct(
         protected string $relation,
+        protected string $alias,
     ) {}
 
    /**
@@ -38,6 +41,16 @@ abstract class Cardinality
     public function getRelationInstance(): object
     {
         return new $this->relation;
+    }
+
+    /**
+     * Get the alias of the related table in query results.
+     *
+     * @return string Relationship alias in query results.
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
     }
 
     /**

--- a/src/Attributes/Cardinality.php
+++ b/src/Attributes/Cardinality.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use Attribute;
+
+/**
+ * Base class for OneToMany and ManyToOne Attributes.
+ */
+abstract class Cardinality
+{
+    /**
+     * Initialize with the two related classes, left and right.  The
+     * cardinality is from left to right, like a RDBMS.
+     *
+     * @param string $left - The left Data Object class.
+     * @param string $right - The right, related Data Object class.
+     */
+    public function __construct(
+        protected string $left,
+        protected string $right,
+    ) {}
+
+    /**
+     * Get an instance of the left class.
+     *
+     * @return object A Data Object instance.
+     */
+    public function getLeftInstance(): object
+    {
+        return new $this->left;
+    }
+
+   /**
+    * Get an instance of the right class.
+    *
+    * @return object A Data Object instance.
+    */
+    public function getRightInstance(): object
+    {
+        return new $this->right;
+    }
+
+    /**
+     * Describe the relationship from left to right.
+     *
+     * @return string
+     */
+    abstract public function describe(): string;
+}

--- a/src/Attributes/CardinalityTest.php
+++ b/src/Attributes/CardinalityTest.php
@@ -6,23 +6,24 @@ use PHPUnit\Framework\TestCase;
 
 use PDGA\DataObjects\Attributes\OneToMany;
 
-// Test classes.  A Person has Phone Numbers (OTM cardinality).
-class Person {}
-class PhoneNumber {}
+class TestPhoneNumber {}
 
 class CardinalityTest extends TestCase
 {
-    public function testLeftInstance(): void
+    public function testRelationClass(): void
     {
-        $card = new OneToMany(Person::class, PhoneNumber::class);
+        $card = new OneToMany(TestPhoneNumber::class);
 
-        $this->assertTrue($card->getLeftInstance() instanceof Person);
+        $this->assertEquals(
+            'PDGA\DataObjects\Attributes\TestPhoneNumber',
+            $card->getRelationClass(),
+        );
     }
 
-    public function testRightInstance(): void
+    public function testRelationInstance(): void
     {
-        $card = new OneToMany(Person::class, PhoneNumber::class);
+        $card = new OneToMany(TestPhoneNumber::class);
 
-        $this->assertTrue($card->getRightInstance() instanceof PhoneNumber);
+        $this->assertTrue($card->getRelationInstance() instanceof TestPhoneNumber);
     }
 }

--- a/src/Attributes/CardinalityTest.php
+++ b/src/Attributes/CardinalityTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use PHPUnit\Framework\TestCase;
+
+use PDGA\DataObjects\Attributes\OneToMany;
+
+// Test classes.  A Person has Phone Numbers (OTM cardinality).
+class Person {}
+class PhoneNumber {}
+
+class CardinalityTest extends TestCase
+{
+    public function testLeftInstance(): void
+    {
+        $card = new OneToMany(Person::class, PhoneNumber::class);
+
+        $this->assertTrue($card->getLeftInstance() instanceof Person);
+    }
+
+    public function testRightInstance(): void
+    {
+        $card = new OneToMany(Person::class, PhoneNumber::class);
+
+        $this->assertTrue($card->getRightInstance() instanceof PhoneNumber);
+    }
+}

--- a/src/Attributes/CardinalityTest.php
+++ b/src/Attributes/CardinalityTest.php
@@ -12,7 +12,7 @@ class CardinalityTest extends TestCase
 {
     public function testRelationClass(): void
     {
-        $card = new OneToMany(TestPhoneNumber::class);
+        $card = new OneToMany(TestPhoneNumber::class, 'PhoneNumbers');
 
         $this->assertEquals(
             'PDGA\DataObjects\Attributes\TestPhoneNumber',
@@ -22,8 +22,15 @@ class CardinalityTest extends TestCase
 
     public function testRelationInstance(): void
     {
-        $card = new OneToMany(TestPhoneNumber::class);
+        $card = new OneToMany(TestPhoneNumber::class, 'PhoneNumbers');
 
         $this->assertTrue($card->getRelationInstance() instanceof TestPhoneNumber);
+    }
+
+    public function testGetAlias(): void
+    {
+        $card = new OneToMany(TestPhoneNumber::class, 'PhoneNumbers');
+
+        $this->assertEquals('PhoneNumbers', $card->getAlias());
     }
 }

--- a/src/Attributes/ManyToOne.php
+++ b/src/Attributes/ManyToOne.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use Attribute;
+
+use PDGA\DataObjects\Attributes\Cardinality;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ManyToOne extends Cardinality
+{
+    /**
+     * Describe the relationship from left to right.
+     *
+     * @return string Always "ManyToOne"
+     */
+    public function describe(): string
+    {
+        return "ManyToOne";
+    }
+}

--- a/src/Attributes/ManyToOne.php
+++ b/src/Attributes/ManyToOne.php
@@ -14,7 +14,7 @@ class ManyToOne extends Cardinality
      *
      * @return string Always "ManyToOne"
      */
-    public function describe(): string
+    public function getDescription(): string
     {
         return "ManyToOne";
     }

--- a/src/Attributes/ManyToOneTest.php
+++ b/src/Attributes/ManyToOneTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use PHPUnit\Framework\TestCase;
+
+use PDGA\DataObjects\Attributes\ManyToOne;
+
+class ManyToOneTest extends TestCase
+{
+    public function testDescription(): void
+    {
+        // Classes are ignored here.
+        $card = new ManyToOne(object::class, object::class);
+        $this->assertEquals('ManyToOne', $card->describe());
+    }
+}

--- a/src/Attributes/ManyToOneTest.php
+++ b/src/Attributes/ManyToOneTest.php
@@ -11,7 +11,7 @@ class ManyToOneTest extends TestCase
     public function testDescription(): void
     {
         // Class is ignored here.
-        $card = new ManyToOne(object::class);
+        $card = new ManyToOne(object::class, 'fake');
         $this->assertEquals('ManyToOne', $card->getDescription());
     }
 }

--- a/src/Attributes/ManyToOneTest.php
+++ b/src/Attributes/ManyToOneTest.php
@@ -10,8 +10,8 @@ class ManyToOneTest extends TestCase
 {
     public function testDescription(): void
     {
-        // Classes are ignored here.
-        $card = new ManyToOne(object::class, object::class);
-        $this->assertEquals('ManyToOne', $card->describe());
+        // Class is ignored here.
+        $card = new ManyToOne(object::class);
+        $this->assertEquals('ManyToOne', $card->getDescription());
     }
 }

--- a/src/Attributes/OneToMany.php
+++ b/src/Attributes/OneToMany.php
@@ -14,7 +14,7 @@ class OneToMany extends Cardinality
      *
      * @return string Always "OneToMany"
      */
-    public function describe(): string
+    public function getDescription(): string
     {
         return "OneToMany";
     }

--- a/src/Attributes/OneToMany.php
+++ b/src/Attributes/OneToMany.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use Attribute;
+
+use PDGA\DataObjects\Attributes\Cardinality;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class OneToMany extends Cardinality
+{
+    /**
+     * Describe the relationship from left to right.
+     *
+     * @return string Always "OneToMany"
+     */
+    public function describe(): string
+    {
+        return "OneToMany";
+    }
+}

--- a/src/Attributes/OneToManyTest.php
+++ b/src/Attributes/OneToManyTest.php
@@ -11,7 +11,7 @@ class OneToManyTest extends TestCase
     public function testDescription(): void
     {
         // Class is ignored here.
-        $card = new OneToMany(object::class, object::class);
+        $card = new OneToMany(object::class, 'fake');
         $this->assertEquals('OneToMany', $card->getDescription());
     }
 }

--- a/src/Attributes/OneToManyTest.php
+++ b/src/Attributes/OneToManyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PDGA\DataObjects\Attributes;
+
+use PHPUnit\Framework\TestCase;
+
+use PDGA\DataObjects\Attributes\OneToMany;
+
+class OneToManyTest extends TestCase
+{
+    public function testDescription(): void
+    {
+        // Classes are ignored here.
+        $card = new OneToMany(object::class, object::class);
+        $this->assertEquals('OneToMany', $card->describe());
+    }
+}

--- a/src/Attributes/OneToManyTest.php
+++ b/src/Attributes/OneToManyTest.php
@@ -10,8 +10,8 @@ class OneToManyTest extends TestCase
 {
     public function testDescription(): void
     {
-        // Classes are ignored here.
+        // Class is ignored here.
         $card = new OneToMany(object::class, object::class);
-        $this->assertEquals('OneToMany', $card->describe());
+        $this->assertEquals('OneToMany', $card->getDescription());
     }
 }

--- a/src/Enforcers/ValidationEnforcer.php
+++ b/src/Enforcers/ValidationEnforcer.php
@@ -11,6 +11,7 @@ use PDGA\DataObjects\Validators\FloatValidator;
 use PDGA\DataObjects\Validators\IntValidator;
 use PDGA\DataObjects\Validators\NotBlankValidator;
 use PDGA\DataObjects\Validators\NotNullValidator;
+use PDGA\DataObjects\Validators\SequentialArrayValidator;
 use PDGA\DataObjects\Validators\StringValidator;
 use PDGA\DataObjects\Validators\Validator;
 use PDGA\Exception\ValidationListException;
@@ -85,6 +86,7 @@ class ValidationEnforcer
             "float"    => new FloatValidator(),
             "DateTime" => new DateValidator(),
             "notNull"  => new NotNullValidator(),
+            "array"    => new SequentialArrayValidator(),
         ];
 
         $metadata = [];

--- a/src/Enforcers/ValidationEnforcerTest.php
+++ b/src/Enforcers/ValidationEnforcerTest.php
@@ -13,6 +13,7 @@ class Person
     public ?string $email;
     public int $id;
     public ?string $name;
+    public array $widgets;
 }
 
 class ValidationEnforcerTest extends TestCase
@@ -190,6 +191,35 @@ class ValidationEnforcerTest extends TestCase
         {
             $this->assertEquals(1, count($e->getErrors()));
             $this->assertEquals('The name field must not be blank.', $e->getErrors()['name'][0]['message']);
+        }
+    }
+
+    public function testNestedArray(): void
+    {
+        $person = ['id' => 42, 'widgets' => [1, 2, 3]];
+        try
+        {
+            $this->enforcer->enforce($person, Person::class);
+            $this->assertTrue(true);
+        }
+        catch (ValidationListException $e)
+        {
+            $this->assertTrue(false, 'Array validation failed.');
+        }
+
+        $person = ['id' => 42, 'widgets' => ['a' => 'b']];
+        try
+        {
+            $this->enforcer->enforce($person, Person::class);
+            $this->assertTrue(false, 'Array validation failed (assoc)');
+        }
+        catch (ValidationListException $e)
+        {
+            $this->assertEquals(1, count($e->getErrors()));
+            $this->assertEquals(
+                'The widgets field must be a sequential (non-associative) zero-indexed array.',
+                 $e->getErrors()['widgets'][0]['message'],
+            );
         }
     }
 }

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -167,15 +167,28 @@ class ModelInstantiator
         object $data_object
     ): array
     {
-        $array = [];
-
-        // Set all Column-attributed properties to a key-value in the outgoing array.
-        foreach ($this->dataObjectProperties($data_object::class) as $property)
+        // Internal driver function that recursively converts an object to an
+        // array and accepts a mixed-type argument.
+        $to_array = function(mixed $data_obj) use (&$to_array)
         {
-            $array[$property] = $data_object->{$property};
-        }
+            if (is_null($data_obj) || is_scalar($data_obj))
+            {
+                return $data_obj;
+            }
 
-        return $array;
+            // $data_obj is an array or object.  Cast to array, then cast each
+            // element recursively.
+            $arr = (array) $data_obj;
+
+            foreach ($arr as &$ele)
+            {
+                $ele = $to_array($ele);
+            }
+
+            return $arr;
+        };
+
+        return $to_array($data_object);
     }
 
     /**

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -142,15 +142,21 @@ class ModelInstantiator
     ): object
     {
         $data_object = new $class();
+        $enforcer    = new ValidationEnforcer();
 
         // Set all Column-attributed properties to the corresponding database column value.
         foreach ($this->dataObjectPropertyColumns($class) as $property => $column)
         {
-            // Set property; apply value converter when applicable.
-            $data_object->{$property} = $this->convertPropertyOnRetrieve(
-                $column,
-                $db_model[$column->getName()],
-            );
+            $col_name = $column->getName();
+
+            if ($enforcer->propIsDefined($db_model, $col_name))
+            {
+                // Set property; apply value converter when applicable.
+                $data_object->{$property} = $this->convertPropertyOnRetrieve(
+                    $column,
+                    $db_model[$column->getName()],
+                );
+            }
         }
 
         return $data_object;

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -154,7 +154,7 @@ class ModelInstantiator
                 // Set property; apply value converter when applicable.
                 $data_object->{$property} = $this->convertPropertyOnRetrieve(
                     $column,
-                    $db_model[$column->getName()],
+                    $db_model[$col_name],
                 );
             }
         }
@@ -166,7 +166,7 @@ class ModelInstantiator
             // from the Cardinality attribute.
             $alias = $card->getAlias();
 
-            if (!$enforcer->propIsDefined($db_model, $alias))
+            if ($enforcer->propIsUndefined($db_model, $alias))
             {
                 continue;
             }

--- a/src/Models/Test/Member.php
+++ b/src/Models/Test/Member.php
@@ -2,13 +2,17 @@
 
 namespace PDGA\DataObjects\Models\Test;
 
+use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Attributes\OneToMany;
 use PDGA\DataObjects\Models\Test\PhoneNumber;
 
 class Member
 {
+    #[Column('PDGANumber')]
     public int $pdgaNumber;
+    #[Column('FirstName')]
     public string $firstName;
+    #[Column('LastName')]
     public string $lastName;
 
     #[OneToMany(PhoneNumber::class, 'PhoneNumbers')]

--- a/src/Models/Test/Member.php
+++ b/src/Models/Test/Member.php
@@ -11,6 +11,6 @@ class Member
     public string $firstName;
     public string $lastName;
 
-    #[OneToMany(PhoneNumber::class)]
+    #[OneToMany(PhoneNumber::class, 'PhoneNumbers')]
     public array $phoneNumbers;
 }

--- a/src/Models/Test/Member.php
+++ b/src/Models/Test/Member.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PDGA\DataObjects\Models\Test;
+
+use PDGA\DataObjects\Attributes\OneToMany;
+use PDGA\DataObjects\Models\Test\PhoneNumber;
+
+class Member
+{
+    public int $pdgaNumber;
+    public string $firstName;
+    public string $lastName;
+
+    #[OneToMany(PhoneNumber::class)]
+    public array $phoneNumbers;
+}

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -244,6 +244,22 @@ class ModelInstantiatorTest extends TestCase
         );
     }
 
+    public function testPartialDataObjectToArray(): void
+    {
+        $data_object               = new ModelInstantiatorTestObject();
+        $data_object->firstName    = 'Ken';
+        $data_object->lastName     = 'Climo';
+
+        $this->assertSame(
+            [
+                'firstName'    => 'Ken',
+                'lastName'     => 'Climo',
+                'testProperty' => false, // Default.
+            ],
+            $this->model_instantiator->dataObjectToArray($data_object)
+        );
+    }
+
     public function testDataObjectPropertyColumns()
     {
         // We should get an array with property names as keys and the corresponding Column attributes as values.

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace PDGA\DataObjects\Models;
+namespace PDGA\DataObjects\Models\Test;
 
 use PDGA\Exception\ValidationListException;
 use PHPUnit\Framework\TestCase;
+
+use PDGA\DataObjects\Models\ModelInstantiator;
 
 class ModelInstantiatorTest extends TestCase
 {

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -218,6 +218,20 @@ class ModelInstantiatorTest extends TestCase
         );
     }
 
+    public function testPartialDatabaseModelToDataObject(): void
+    {
+        // Partial DB model for a ModelInstantiatorTestObject.
+        $db_model = ['PDGANum' => 4297];
+
+        $data_object             = new ModelInstantiatorTestObject();
+        $data_object->pdgaNumber = 4297;
+
+        $this->assertEquals(
+            $data_object,
+            $this->model_instantiator->databaseModelToDataObject($db_model, ModelInstantiatorTestObject::class)
+        );
+    }
+
     public function testDataObjectToArray(): void
     {
         // Create an input Data Object instance.

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -232,6 +232,64 @@ class ModelInstantiatorTest extends TestCase
         );
     }
 
+    public function testDatabaseModelToDataObjectNestedArray(): void
+    {
+        $member_db = [
+            'PDGANumber'   => 42,
+            'FirstName'    => 'Franko',
+            'PhoneNumbers' => [
+                ['Phone' => '999-999-9999']
+            ],
+        ];
+
+        $member = $this->model_instantiator->databaseModelToDataObject(
+            $member_db,
+            Member::class,
+        );
+
+        $member_arr = $this->model_instantiator->dataObjectToArray($member);
+
+        $this->assertEqualsCanonicalizing(
+            [
+                'pdgaNumber'   => 42,
+                'firstName'    => 'Franko',
+                'phoneNumbers' => [
+                    ['phone' => '999-999-9999']
+                ],
+            ],
+            $member_arr,
+        );
+    }
+
+    public function testDatabaseModelToDataObjectNestedObject(): void
+    {
+        $phone_db = [
+            'Phone' => '999-999-9999',
+            'Member' => [
+                'PDGANumber' => 42,
+                'LastName'   => 'Salentino',
+            ],
+        ];
+
+        $phone = $this->model_instantiator->databaseModelToDataObject(
+            $phone_db,
+            PhoneNumber::class,
+        );
+
+        $phone_arr = $this->model_instantiator->dataObjectToArray($phone);
+
+        $this->assertEqualsCanonicalizing(
+            [
+                'phone'  => '999-999-9999',
+                'member' => [
+                    'pdgaNumber' => 42,
+                    'lastName'   => 'Salentino',
+                ],
+            ],
+            $phone_arr,
+        );
+    }
+
     public function testDataObjectToArray(): void
     {
         // Create an input Data Object instance.

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -260,6 +260,41 @@ class ModelInstantiatorTest extends TestCase
         );
     }
 
+    public function testDataObjectToArrayNested(): void
+    {
+        // This is a goofy structure, but it tests recursion of both nested
+        // objects and arrays.  A Member with one Phone Number with a Member.
+        $member = new Member();
+        $member->pdgaNumber = 42;
+        $member->firstName  = 'Jane';
+
+        $member->phoneNumbers = [new PhoneNumber()];
+        $member->phoneNumbers[0]->pdgaNumber = 42;
+        $member->phoneNumbers[0]->phone      = '123-456-7890';
+
+        $member->phoneNumbers[0]->member = new Member();
+        $member->phoneNumbers[0]->member->pdgaNumber = 42;
+        $member->phoneNumbers[0]->member->firstName  = 'Jane';
+
+        $this->assertEqualsCanonicalizing(
+            [
+                'firstName'    => 'Jane',
+                'pdgaNumber'   => 42,
+                'phoneNumbers' => [
+                    [
+                        'pdgaNumber' => 42,
+                        'phone' => '123-456-7890',
+                        'member' => [
+                            'firstName'    => 'Jane',
+                            'pdgaNumber'   => 42,
+                        ],
+                    ],
+                ],
+            ],
+            $this->model_instantiator->dataObjectToArray($member),
+        );
+    }
+
     public function testDataObjectPropertyColumns()
     {
         // We should get an array with property names as keys and the corresponding Column attributes as values.

--- a/src/Models/Test/ModelInstantiatorTestObject.php
+++ b/src/Models/Test/ModelInstantiatorTestObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PDGA\DataObjects\Models;
+namespace PDGA\DataObjects\Models\Test;
 
 use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Attributes\Table;

--- a/src/Models/Test/PhoneNumber.php
+++ b/src/Models/Test/PhoneNumber.php
@@ -2,12 +2,15 @@
 
 namespace PDGA\DataObjects\Models\Test;
 
+use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Attributes\ManyToOne;
 use PDGA\DataObjects\Models\Test\Member;
 
 class PhoneNumber
 {
+    #[Column('PDGANumber')]
     public int $pdgaNumber;
+    #[Column('Phone')]
     public string $phone;
 
     #[ManyToOne(Member::class, 'Member')]

--- a/src/Models/Test/PhoneNumber.php
+++ b/src/Models/Test/PhoneNumber.php
@@ -10,6 +10,6 @@ class PhoneNumber
     public int $pdgaNumber;
     public string $phone;
 
-    #[ManyToOne(Member::class)]
+    #[ManyToOne(Member::class, 'Member')]
     public Member $member;
 }

--- a/src/Models/Test/PhoneNumber.php
+++ b/src/Models/Test/PhoneNumber.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PDGA\DataObjects\Models\Test;
+
+use PDGA\DataObjects\Attributes\ManyToOne;
+use PDGA\DataObjects\Models\Test\Member;
+
+class PhoneNumber
+{
+    public int $pdgaNumber;
+    public string $phone;
+
+    #[ManyToOne(Member::class)]
+    public Member $member;
+}


### PR DESCRIPTION
- Adds `Cardinality` attributes, `OneToMany` and `ManyToOne`, for defining relationships on Data Objects.
- Enforces `array-`type properties using `SequentialArrayValidator` in `ValidationEnforcer`.
- Enhances `ModelInstantiator#arrayToDataObject` to recursively instantiate nested Data Objects, using the new `Cardinality` attributes for relationship metadata.
- Likewise, `ModelInstantiator#databaseModelToDataObject` now recursively instantiates nested Data Objects from DB models.
- Fixed a crash in `ModelInstantiator#databaseModelToDataObject` when converting partial DB models (i.e. when only some columns are selected), and wrote a test for this case.
- Fixed a similar crash in `ModelInstantiator#dataObjectToArray` when converting partially hydrated Data Objects, and wrote a test case.
- `ModelInstantiator#dataObjectToArray` no recursively converts Data Objects, so relations get converted to arrays as well.

I considered updating the `ValidationEnforcer` and its sub-classes to recursively validate, which is doable but somewhat complicated.  The `ModelInstantiator` of course validates nested relations recursively, and I think that's the main way we're going to create Data Objects.