### PR TITLE
bdb/dont-run-null-properties-through-converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-### 1.6.0
+### 1.5.1
 * `ModelInstantiator` no longer passes `NULL`/`null` values to `Converter`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+### 1.6.0
+* `ModelInstantiator` no longer passes `NULL`/`null` values to `Converter`s.

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -379,7 +379,7 @@ class ModelInstantiator
     ): mixed
     {
         // No Converter for this Column; return the original value.
-        if (!$column->getConverter() || $property === null)
+        if (!$column->getConverter())
         {
             return $property;
         }

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -353,7 +353,9 @@ class ModelInstantiator
             return $property;
         }
 
-        return $column->getConverter()->onSave($property);
+        return $property === null
+            ? null
+            : $column->getConverter()->onSave($property);
     }
 
     /**
@@ -375,6 +377,8 @@ class ModelInstantiator
             return $property;
         }
 
-        return $column->getConverter()->onRetrieve($property);
+        return $property === null
+            ? null
+            : $column->getConverter()->onRetrieve($property);
     }
 }

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -348,12 +348,19 @@ class ModelInstantiator
         mixed  $property,
     ): mixed
     {
-        // If there's no converter OR the property is null, then return the original value.
-        if (!$column->getConverter() || $property === null)
+        // No Converter for this Column; return the original value.
+        if (!$column->getConverter())
         {
             return $property;
         }
 
+        // If the property is null, then return null.
+        if ($property === null)
+        {
+            return $property;
+        }
+
+        // Convert for save.
         return $column->getConverter()->onSave($property);
     }
 
@@ -371,8 +378,14 @@ class ModelInstantiator
         mixed  $property,
     ): mixed
     {
-        // If there's no converter OR the property is null, then return the original value.
+        // No Converter for this Column; return the original value.
         if (!$column->getConverter() || $property === null)
+        {
+            return $property;
+        }
+
+        // If the property is null, then return null.
+        if ($property === null)
         {
             return $property;
         }

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -335,7 +335,8 @@ class ModelInstantiator
     }
 
     /**
-     * Converts a property for saving if there is a 'converter' value of its Attribute.
+     * Converts a property for saving if there is a 'converter' value of its
+     * Attribute and the property is not null.
      *
      * @param Column $column
      * @param mixed  $property
@@ -347,19 +348,18 @@ class ModelInstantiator
         mixed  $property,
     ): mixed
     {
-        // No Converter for this Column; return the original value.
-        if (!$column->getConverter())
+        // If there's no converter OR the property is null, then return the original value.
+        if (!$column->getConverter() || $property === null)
         {
             return $property;
         }
 
-        return $property === null
-            ? null
-            : $column->getConverter()->onSave($property);
+        return $column->getConverter()->onSave($property);
     }
 
     /**
-     * Converts a property for retrieval if there is a 'converter' value of its Attribute.
+     * Converts a property on retrieval if there is a 'converter' value of its
+     * Attribute and the property is not null.
      *
      * @param Column $column
      * @param mixed  $property
@@ -371,14 +371,12 @@ class ModelInstantiator
         mixed  $property,
     ): mixed
     {
-        // No Converter for this Column; return the original value.
-        if (!$column->getConverter())
+        // If there's no converter OR the property is null, then return the original value.
+        if (!$column->getConverter() || $property === null)
         {
             return $property;
         }
 
-        return $property === null
-            ? null
-            : $column->getConverter()->onRetrieve($property);
+        return $column->getConverter()->onRetrieve($property);
     }
 }

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -422,6 +422,24 @@ class ModelInstantiatorTest extends TestCase
         );
     }
 
+    public function testDontConvertNullPropertyOnSave()
+    {
+        // Privacy uses the yes/no converter, but it's null so it shouldn't be
+        // converted.
+        $data_object = new ModelInstantiatorTestObject();
+        $data_object->privacy = null;
+        $property_reflection = $this->model_instantiator->dataObjectProperties(ModelInstantiatorTestObject::class);
+
+        $columns = $this->model_instantiator->dataObjectPropertyColumns($property_reflection);
+
+        $this->assertNull(
+            $this->model_instantiator->convertPropertyOnSave(
+                $columns['privacy'],
+                $data_object->privacy,
+            )
+        );
+    }
+
     public function testConvertPropertyOnRetrieve()
     {
         // Create a db model with a property that uses the YesNoConverter.
@@ -435,6 +453,23 @@ class ModelInstantiatorTest extends TestCase
         // 'No' should return boolean false when converting to a Data Object.
         $this->assertSame(
             false,
+            $this->model_instantiator->convertPropertyOnRetrieve(
+                $columns['privacy'],
+                $db_model['Privacy'],
+            )
+        );
+    }
+
+    public function testDontConvertNullPropertyOnRetrieve()
+    {
+        $db_model = [
+            'Privacy' => null,
+        ];
+
+        $property_reflection = $this->model_instantiator->dataObjectProperties(ModelInstantiatorTestObject::class);
+        $columns = $this->model_instantiator->dataObjectPropertyColumns($property_reflection);
+
+        $this->assertNull(
             $this->model_instantiator->convertPropertyOnRetrieve(
                 $columns['privacy'],
                 $db_model['Privacy'],


### PR DESCRIPTION
I made this change because of a bug I found during this morning's API meeting.  In a nutshell, `NULL` values from the database get converted using `Converter` classes.  For example, a `NULL` value in a `DATETIME` column gets converted on retrieve by the [`DateTimeConverter`](https://github.com/PDGA/php-data-objects/blob/1.5.0/src/Converters/DateTimeConverter.php), and the result is the current time.  That's a bug.

Since converters only run on `Column`-attributed properties, I think this is the correct way to fix this issue--namely, not passing `null` values to converters.  The downside of this approach is that we can't convert `null` values, but I don't think we would ever want to convert `null` values in columns.  The alternative would be to check for `null` in each `Converter`.