### PR TITLE
dataObjectPropertyColumns and dataObjectPropertyCardinalities functions now check for conditions that should return an empty array and memoize the empty array for future use

### DIFF
--- a/src/Models/ReflectionContainer.php
+++ b/src/Models/ReflectionContainer.php
@@ -28,18 +28,15 @@ class ReflectionContainer
         array $props
     ): array
     {
-        // Empty props should result in an empty array.
-        if (!count($props))
-        {
-            return [];
-        }
-
         $class = $props[0]->class;
 
         if (array_key_exists($class, $this->column_reflection))
         {
             return $this->column_reflection[$class];
         }
+
+        // Default the class to an empty array.
+        $this->column_reflection[$class] = [];
 
         // Loop through all ReflectionProperties.
         foreach ($props as $property)
@@ -54,12 +51,6 @@ class ReflectionContainer
             }
 
             $this->column_reflection[$class][$property->getName()] = $attribute[0]->newInstance();
-        }
-
-        // If the props didn't generate any attributes, set an empty array for this class.
-        if (!array_key_exists($class, $this->column_reflection))
-        {
-            $this->column_reflection[$class] = [];
         }
 
         return $this->column_reflection[$class];
@@ -80,18 +71,15 @@ class ReflectionContainer
         array $props
     ): array
     {
-        // Empty props should result in an empty array.
-        if (!count($props))
-        {
-            return [];
-        }
-
         $class = $props[0]->class;
 
         if (array_key_exists($class, $this->card_reflection))
         {
             return $this->card_reflection[$class];
         }
+
+        // Default the class to an empty array.
+        $this->column_reflection[$class] = [];
 
         foreach ($props as $prop)
         {
@@ -106,12 +94,6 @@ class ReflectionContainer
             }
 
             $this->card_reflection[$class][$prop->getName()] = $attrs[0]->newInstance();
-        }
-
-        // If the props didn't generate any attributes, set an empty array for this class.
-        if (!array_key_exists($class, $this->card_reflection))
-        {
-            $this->card_reflection[$class] = [];
         }
 
         return $this->card_reflection[$class];

--- a/src/Models/ReflectionContainer.php
+++ b/src/Models/ReflectionContainer.php
@@ -30,6 +30,12 @@ class ReflectionContainer
     {
         $class = $props[0]->class;
 
+        // Empty props should result in an empty array.
+        if (!count($props))
+        {
+            $this->column_reflection[$class] = [];
+        }
+
         if (array_key_exists($class, $this->column_reflection))
         {
             return $this->column_reflection[$class];
@@ -48,6 +54,12 @@ class ReflectionContainer
             }
 
             $this->column_reflection[$class][$property->getName()] = $attribute[0]->newInstance();
+        }
+
+        // If the props didn't generate any attributes, set an empty array for this class.
+        if (!array_key_exists($class, $this->column_reflection))
+        {
+            $this->column_reflection[$class] = [];
         }
 
         return $this->column_reflection[$class];
@@ -70,6 +82,12 @@ class ReflectionContainer
     {
         $class = $props[0]->class;
 
+        // Empty props should result in an empty array.
+        if (!count($props))
+        {
+            $this->card_reflection[$class] = [];
+        }
+
         if (array_key_exists($class, $this->card_reflection))
         {
             return $this->card_reflection[$class];
@@ -90,7 +108,13 @@ class ReflectionContainer
             $this->card_reflection[$class][$prop->getName()] = $attrs[0]->newInstance();
         }
 
-        return $this->card_reflection[$class] ?? [];
+        // If the props didn't generate any attributes, set an empty array for this class.
+        if (!array_key_exists($class, $this->card_reflection))
+        {
+            $this->card_reflection[$class] = [];
+        }
+
+        return $this->card_reflection[$class];
     }
 
     /**

--- a/src/Models/ReflectionContainer.php
+++ b/src/Models/ReflectionContainer.php
@@ -28,13 +28,13 @@ class ReflectionContainer
         array $props
     ): array
     {
-        $class = $props[0]->class;
-
         // Empty props should result in an empty array.
         if (!count($props))
         {
-            $this->column_reflection[$class] = [];
+            return [];
         }
+
+        $class = $props[0]->class;
 
         if (array_key_exists($class, $this->column_reflection))
         {
@@ -80,13 +80,13 @@ class ReflectionContainer
         array $props
     ): array
     {
-        $class = $props[0]->class;
-
         // Empty props should result in an empty array.
         if (!count($props))
         {
-            $this->card_reflection[$class] = [];
+            return [];
         }
+
+        $class = $props[0]->class;
 
         if (array_key_exists($class, $this->card_reflection))
         {

--- a/src/Models/Test/Address.php
+++ b/src/Models/Test/Address.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PDGA\DataObjects\Models\Test;
+
+use PDGA\DataObjects\Attributes\Column;
+
+class Address
+{
+    #[Column('Number')]
+    public int $number;
+    #[Column('Street')]
+    public string $street;
+}

--- a/src/Models/Test/Members.php
+++ b/src/Models/Test/Members.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PDGA\DataObjects\Models\Test;
+
+use PDGA\DataObjects\Attributes\ManyToOne;
+use PDGA\DataObjects\Models\Test\Member;
+
+class Members
+{
+    #[ManyToOne(Member::class, 'Member')]
+    public array $members;
+}

--- a/src/Models/Test/ReflectionContainerTest.php
+++ b/src/Models/Test/ReflectionContainerTest.php
@@ -7,7 +7,9 @@ use ReflectionClass;
 use PHPUnit\Framework\TestCase;
 
 use PDGA\DataObjects\Models\ReflectionContainer;
+use PDGA\DataObjects\Models\Test\Address;
 use PDGA\DataObjects\Models\Test\Member;
+use PDGA\DataObjects\Models\Test\Members;
 use PDGA\DataObjects\Models\Test\ModelInstantiatorTestObject;
 use PDGA\DataObjects\Attributes\ManyToOne;
 use PDGA\DataObjects\Attributes\OneToMany;
@@ -59,5 +61,27 @@ class ReflectionContainerTest extends TestCase
         // properties of the cardinality objects are protected.
         $this->assertTrue($member_cardinalities['phoneNumbers'] instanceof OneToMany);
         $this->assertTrue($phone_number_cardinalities['member'] instanceof ManyToOne);
+    }
+
+    public function testDataObjectPropertyColumnsReturnsEmptyArray()
+    {
+        $members_proprety_reflection = $this->reflection_container->dataObjectProperties(Members::class);
+
+        $no_columns = $this->reflection_container->dataObjectPropertyColumns($members_proprety_reflection);
+        $no_props   = $this->reflection_container->dataObjectPropertyColumns([]);
+
+        $this->assertTrue($no_columns === []);
+        $this->assertTrue($no_props === []);
+    }
+
+    public function testDataObjectPropertyCardinalitiesReturnsEmptyArray()
+    {
+        $address_proprety_reflection = $this->reflection_container->dataObjectProperties(Address::class);
+
+        $no_cardinalities = $this->reflection_container->dataObjectPropertyCardinalities($address_proprety_reflection);
+        $no_props         = $this->reflection_container->dataObjectPropertyCardinalities([]);
+
+        $this->assertTrue($no_cardinalities === []);
+        $this->assertTrue($no_props === []);
     }
 }


### PR DESCRIPTION
I believe this addresses the issue in the Jira task but if there is some extra fine tuning that needs to be done please let me know.

See [https://pdga.atlassian.net/browse/PDGA-386](https://pdga.atlassian.net/browse/PDGA-386)