### PR TITLE
updated check for undefined properties to be a check for null properties which includes undefined

### DIFF
--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -201,7 +201,7 @@ class ModelInstantiator
             // from the Cardinality attribute.
             $alias = $card->getAlias();
 
-            if ($enforcer->propIsUndefined($model_relations, $alias))
+            if ($enforcer->propIsNull($model_relations, $alias))
             {
                 continue;
             }


### PR DESCRIPTION
Tim has an eloquent query which includes sub-resources (specifically a `Member` object if `PDGANum` is defined for a `LiveResult` object) that is returning null but the model instantiator still tries to instantiate an instance of Member.  The `propIsUndefined` only checks that the property is defined on the object, not that the value associated with that property is valid. The `propIsNull` checks both things.