### PR TITLE
Relationship parsing and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.phpunit.result.cache

--- a/src/Parsers/DataObjectRelationshipParser.php
+++ b/src/Parsers/DataObjectRelationshipParser.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PDGA\DataObjects\Parsers;
+
+use PDGA\DataObjects\Models\ReflectionContainer;
+use PDGA\Exception\ValidationException;
+
+class DataObjectRelationshipParser
+{
+    public function __construct(
+        private readonly ReflectionContainer $reflection_container = new ReflectionContainer()
+    )
+    {}
+
+    /**
+     * For a given Data Object class, this will provide the names of the Cardinality relationships that are defined.
+     *
+     * @param string $data_object_class
+     * @return array
+     * @throws \ReflectionException
+     */
+    public function getRelationshipAliasesForDataObject(string $data_object_class): array
+    {
+        $properties = $this->reflection_container->dataObjectProperties($data_object_class);
+        $cardinalities = $this->reflection_container->dataObjectPropertyCardinalities($properties);
+
+        return array_map(fn($cardinality) => $cardinality->getAlias(), $cardinalities);
+    }
+
+    /**
+     * Parses a comma delimited string that specifies relationships and returns an
+     * array of parsed valid relationship names.
+     *
+     * @param string|null $relationships_to_parse
+     * @param string $data_object_class
+     * @return array
+     * @throws ValidationException
+     * @throws \ReflectionException
+     */
+    public function parseRelationshipsForDataObject(
+        ?string $relationships_to_parse,
+        string $data_object_class
+    ): array
+    {
+        if (empty($relationships_to_parse))
+        {
+            return [];
+        }
+
+        $valid_relationships = $this->getRelationshipAliasesForDataObject($data_object_class);
+        $includes = array_unique(explode(',', $relationships_to_parse));
+        $relationships_keyed_by_lower = array_combine(
+            array_map('strtolower', $valid_relationships),
+            $valid_relationships
+        );
+
+        $relationships_to_include = [];
+        $invalid_includes = [];
+
+        foreach ($includes as $relationship_to_check)
+        {
+            $lower_relationship_to_check = trim(strtolower($relationship_to_check));
+
+            if (key_exists($lower_relationship_to_check, $relationships_keyed_by_lower))
+            {
+                $relationships_to_include[] = $relationships_keyed_by_lower[$lower_relationship_to_check];
+            }
+            else
+            {
+                $invalid_includes[] = $relationship_to_check;
+            }
+        }
+
+        if (!empty($invalid_includes))
+        {
+            $includes_error = implode(',', $invalid_includes);
+
+            throw new ValidationException("Unknown relationships - {$includes_error}");
+        }
+
+        return $relationships_to_include;
+    }
+}

--- a/src/Parsers/DataObjectRelationshipParser.php
+++ b/src/Parsers/DataObjectRelationshipParser.php
@@ -48,7 +48,7 @@ class DataObjectRelationshipParser
         }
 
         $valid_relationships = $this->getRelationshipAliasesForDataObject($data_object_class);
-        $includes = array_unique(explode(',', $relationships_to_parse));
+        $relationships_to_validate = array_unique(explode(',', $relationships_to_parse));
 
         // This will produce an array of valid relationships keyed by the lowercase name of the relationship which
         // allows us to perform a case-insensitive comparison below.
@@ -60,9 +60,9 @@ class DataObjectRelationshipParser
         $validated_relationships = [];
         $invalid_relationships = [];
 
-        foreach ($includes as $relationship_to_check)
+        foreach ($relationships_to_validate as $relationship_to_validate)
         {
-            $lower_relationship_to_check = trim(strtolower($relationship_to_check));
+            $lower_relationship_to_check = trim(strtolower($relationship_to_validate));
 
             if (key_exists($lower_relationship_to_check, $relationships_keyed_by_lower))
             {
@@ -70,15 +70,15 @@ class DataObjectRelationshipParser
             }
             else
             {
-                $invalid_relationships[] = $relationship_to_check;
+                $invalid_relationships[] = $relationship_to_validate;
             }
         }
 
         if (!empty($invalid_relationships))
         {
-            $includes_error = implode(',', $invalid_relationships);
+            $unknown_relationships = implode(',', $invalid_relationships);
 
-            throw new ValidationException("Unknown relationships - {$includes_error}");
+            throw new ValidationException("Unknown relationships - {$unknown_relationships}");
         }
 
         return $validated_relationships;

--- a/src/Parsers/DataObjectRelationshipParser.php
+++ b/src/Parsers/DataObjectRelationshipParser.php
@@ -49,13 +49,16 @@ class DataObjectRelationshipParser
 
         $valid_relationships = $this->getRelationshipAliasesForDataObject($data_object_class);
         $includes = array_unique(explode(',', $relationships_to_parse));
+
+        // This will produce an array of valid relationships keyed by the lowercase name of the relationship which
+        // allows us to perform a case-insensitive comparison below.
         $relationships_keyed_by_lower = array_combine(
             array_map('strtolower', $valid_relationships),
             $valid_relationships
         );
 
-        $relationships_to_include = [];
-        $invalid_includes = [];
+        $validated_relationships = [];
+        $invalid_relationships = [];
 
         foreach ($includes as $relationship_to_check)
         {
@@ -63,21 +66,21 @@ class DataObjectRelationshipParser
 
             if (key_exists($lower_relationship_to_check, $relationships_keyed_by_lower))
             {
-                $relationships_to_include[] = $relationships_keyed_by_lower[$lower_relationship_to_check];
+                $validated_relationships[] = $relationships_keyed_by_lower[$lower_relationship_to_check];
             }
             else
             {
-                $invalid_includes[] = $relationship_to_check;
+                $invalid_relationships[] = $relationship_to_check;
             }
         }
 
-        if (!empty($invalid_includes))
+        if (!empty($invalid_relationships))
         {
-            $includes_error = implode(',', $invalid_includes);
+            $includes_error = implode(',', $invalid_relationships);
 
             throw new ValidationException("Unknown relationships - {$includes_error}");
         }
 
-        return $relationships_to_include;
+        return $validated_relationships;
     }
 }

--- a/src/Parsers/DataObjectRelationshipParserTest.php
+++ b/src/Parsers/DataObjectRelationshipParserTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace PDGA\DataObjects\Parsers;
+
+use PDGA\DataObjects\Models\Test\ModelInstantiatorTestObject;
+use PDGA\Exception\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class DataObjectRelationshipParserTest extends TestCase
+{
+    private DataObjectRelationshipParser $relationship_parser;
+
+    public function setUp(): void
+    {
+        $this->relationship_parser = new DataObjectRelationshipParser();
+    }
+
+    public function testEmptyRelationshipReturnsEmptyArray()
+    {
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            '',
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals([], $valid_relationships);
+    }
+
+    public function testNullRelationshipReturnsEmptyArray()
+    {
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            null,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals([], $valid_relationships);
+    }
+
+    public function testValidRelationshipIsReturned()
+    {
+        $relationship = "FakeHasOneRelation";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationship,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals($relationship, $valid_relationships[0]);
+    }
+
+    public function testMultipleValidRelationshipsAreReturned()
+    {
+        $relationships = "FakeHasOneRelation,NullableFakeHasOneRelation,FakeHasManyRelation";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationships,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(3, count($valid_relationships));
+        $this->assertEquals(explode(',', $relationships), $valid_relationships);
+    }
+
+    public function testValidRelationshipWithLeadingWhitespaceIsReturned()
+    {
+        $relationship = " FakeHasOneRelation";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationship,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals(trim($relationship), $valid_relationships[0]);
+    }
+
+    public function testValidRelationshipWithTrailingWhitespaceIsReturned()
+    {
+        $relationship = "FakeHasOneRelation ";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationship,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals(trim($relationship), $valid_relationships[0]);
+    }
+
+    public function testDuplicateValidRelationshipsIgnoresDuplicate()
+    {
+        $valid = "FakeHasOneRelation";
+        $relationship = "{$valid},{$valid}";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationship,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals($valid, $valid_relationships[0]);
+    }
+
+    public function testValidRelationshipWithIncorrectCasingIsReturnedAsCorrectCasing()
+    {
+        $expected_correct_casing = "FakeHasOneRelation";
+        $relationship = "fAKEhASoNErELATION";
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationship,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals($expected_correct_casing, $valid_relationships[0]);
+    }
+
+    public function testInvalidRelationshipThrowsException()
+    {
+        $relationship = "invalid";
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationship,
+                ModelInstantiatorTestObject::class
+            );
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Unknown relationships - {$relationship}", $exception->getMessage());
+        }
+    }
+
+    public function testMultipleInvalidRelationshipsAreIncludedInExceptionMessage()
+    {
+        $relationship = "invalid1, invalid2";
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationship,
+                ModelInstantiatorTestObject::class
+            );
+
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Unknown relationships - {$relationship}", $exception->getMessage());
+        }
+    }
+
+    public function testOnlyInvalidRelationshipsAreIncludedInExceptionMessage()
+    {
+        $invalid = " invalid";
+        $relationships = "FakeHasOneRelation,{$invalid}";
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationships,
+                ModelInstantiatorTestObject::class
+            );
+
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Unknown relationships - {$invalid}", $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This currently exists in `php-api` as the `DataObjectRelationshipValidator`. The goal is to move that into this repo.

This adds a parser that will parse a comma delimited string of relationships and validate them against the definition of the specified data object. 

The intent is for this to provide a generic way of validating requested relationships for a data object and provide an array of those validated relationships. That array should be able to be used by a Query Builder. 

This makes use of the existing `ReflectionContainer` to determine what relationships exist on a data object.

This currently does not support nested relationships. That would come in a future update. 

The typical use case in mind is:
- A web request that specifies relationships to include in the response as part of the query string.
- That variable from the query string has to be parsed and validated.
- Once validated, the resulting array of relationships can be used in a `with` clause as part of a Query Builder. 