### PR TITLE
Adds support for parsing and validating nested relationships

### DIFF
--- a/src/Parsers/DataObjectRelationshipParser.php
+++ b/src/Parsers/DataObjectRelationshipParser.php
@@ -13,21 +13,9 @@ class DataObjectRelationshipParser
     {}
 
     /**
-     * For a given Data Object class, this will provide the names of the Cardinality relationships that are defined.
-     *
-     * @param string $data_object_class
-     * @return array
-     * @throws \ReflectionException
-     */
-    public function getRelationshipCardinalitiesForDataObject(string $data_object_class): array
-    {
-        $properties = $this->reflection_container->dataObjectProperties($data_object_class);
-
-        return $this->reflection_container->dataObjectPropertyCardinalities($properties);
-    }
-
-    /**
      * Parses an array of relationship names and returns an array of validated relationship names.
+     * The specified relationships are validated to exist against the aliases of their cardinalities.
+     * The expected convention is that this alias matches the name of the relationship defined on the data Model.
      *
      * @param array $relationships_to_parse
      * @param string $data_object_class
@@ -45,25 +33,22 @@ class DataObjectRelationshipParser
             return [];
         }
 
-        // This will preserve the original value to be used in the exception message
-        $relationships_to_validate_keyed_by_original = array_unique(
-            array_combine(
-                $relationships_to_parse,
-                array_map("strtolower", $relationships_to_parse)
-            )
-        );
-
+        $relationships_to_validate_by_original = $this->getUniqueRelationshipsByOriginal($relationships_to_parse);
         $validated_relationships = [];
         $invalid_relationships = [];
 
-        foreach ($relationships_to_validate_keyed_by_original as $relationship_to_validate_original => $relationship_to_validate_lower)
+        foreach ($relationships_to_validate_by_original as $relationship_to_validate_original => $relationship_to_validate_lower)
         {
             try
             {
-                $validated_relationships[] = $this->getValidRelationship($relationship_to_validate_lower, $data_object_class);
+                $validated_relationships[] = $this->getValidatedRelationship(
+                    $relationship_to_validate_lower,
+                    $data_object_class
+                );
             }
             catch (ValidationException)
             {
+                // Capture all invalid relationships to produce a more useful error message
                 $invalid_relationships[] = $relationship_to_validate_original;
             }
         }
@@ -80,52 +65,96 @@ class DataObjectRelationshipParser
 
     /**
      * Returns the validated name of the relationship.
+     * The specified relationship is validated to exist against the alias of the cardinality. The expected convention
+     * is that this alias matches the name of the relationship defined on the data Model.
+     *
      * Supports nested relationships using dot syntax - For example: parent.child.grandchild
      *
-     * @param string $lower_relationship_to_check
+     * @param string $relationship_to_validate_lower Name of the relationship as lowercase
      * @param string $data_object_class
      * @return string
      * @throws ValidationException
      * @throws \ReflectionException
      */
-    private function getValidRelationship(
-        string $lower_relationship_to_check,
+    private function getValidatedRelationship(
+        string $relationship_to_validate_lower,
         string $data_object_class
     ): string
     {
+        // Separate the parent relationship from the descendants
+        $aliases_to_validate = explode('.', $relationship_to_validate_lower, 2);
+        $alias_to_validate_lower = trim($aliases_to_validate[0]);
 
-        $nested_relationships = explode('.', trim($lower_relationship_to_check), 2);
+        $valid_cardinalities_by_alias_lower = $this->getValidCardinalitiesKeyedByAliasLower($data_object_class);
 
-        $valid_relationship_cardinalities = $this->getRelationshipCardinalitiesForDataObject($data_object_class);
-
-        $cardinality_aliases = array_map(
-            fn ($cardinality) => $cardinality->getAlias(),
-            $valid_relationship_cardinalities
-        );
-
-        // This will produce an array of valid relationships keyed by the lowercase name of the relationship which
-        // allows us to perform a case-insensitive comparison below.
-        $valid_relationships_keyed_by_lower_alias = array_combine(
-            array_map(fn ($alias) => strtolower($alias),$cardinality_aliases),
-            $valid_relationship_cardinalities
-        );
-
-        $relationship_to_validate = trim($nested_relationships[0]);
-
-        if (key_exists($relationship_to_validate, $valid_relationships_keyed_by_lower_alias))
+        // The specified alias does not exist as a known relationship alias
+        if (!key_exists($alias_to_validate_lower, $valid_cardinalities_by_alias_lower))
         {
-            if (count($nested_relationships) > 1)
-            {
-                $relation_class = $valid_relationships_keyed_by_lower_alias[$relationship_to_validate]->getRelationClass();
-
-                return $valid_relationships_keyed_by_lower_alias[$relationship_to_validate]->getAlias()
-                       . '.'
-                       . $this->getValidRelationship($nested_relationships[1], $relation_class);
-            }
-
-            return $valid_relationships_keyed_by_lower_alias[$relationship_to_validate]->getAlias();
+            throw new ValidationException();
         }
 
-        throw new ValidationException();
+        if (count($aliases_to_validate) > 1)
+        {
+            $relation_class = $valid_cardinalities_by_alias_lower[$alias_to_validate_lower]->getRelationClass();
+
+            // Build the validated nested relationship name using recursive call
+            return $valid_cardinalities_by_alias_lower[$alias_to_validate_lower]->getAlias()
+                   . '.'
+                   . $this->getValidatedRelationship($aliases_to_validate[1], $relation_class);
+        }
+
+        return $valid_cardinalities_by_alias_lower[$alias_to_validate_lower]->getAlias();
+    }
+
+    /**
+     * @param string $data_object_class
+     * @return array
+     * @throws \ReflectionException
+     */
+    private function getValidCardinalitiesKeyedByAliasLower(string $data_object_class): array
+    {
+        $valid_relationship_cardinalities = $this->getRelationshipCardinalitiesForDataObject($data_object_class);
+        $cardinality_aliases = array_map(
+            fn($cardinality) => $cardinality->getAlias(),
+            $valid_relationship_cardinalities
+        );
+
+        // Produces an array of valid relationships keyed by the lowercase name of the relationship.
+        // This allows us to ignore differences in casing.
+        return array_combine(
+            array_map(fn($alias) => strtolower($alias), $cardinality_aliases),
+            $valid_relationship_cardinalities
+        );
+    }
+
+    /**
+     * For a given Data Object class, this will provide the names of the Cardinality relationships that are defined.
+     *
+     * @param string $data_object_class
+     * @return array
+     * @throws \ReflectionException
+     */
+    private function getRelationshipCardinalitiesForDataObject(string $data_object_class): array
+    {
+        $properties = $this->reflection_container->dataObjectProperties($data_object_class);
+
+        return $this->reflection_container->dataObjectPropertyCardinalities($properties);
+    }
+
+    /**
+     * Generates an array of lowercase relationship names keys by the original name
+     * Duplicate values are removed.
+     *
+     * @param array $relationships_to_parse
+     * @return array
+     */
+    private function getUniqueRelationshipsByOriginal(array $relationships_to_parse): array
+    {
+        return array_unique(
+            array_combine(
+                $relationships_to_parse,
+                array_map("strtolower", $relationships_to_parse)
+            )
+        );
     }
 }

--- a/src/Parsers/DataObjectRelationshipParserTest.php
+++ b/src/Parsers/DataObjectRelationshipParserTest.php
@@ -38,6 +38,33 @@ class DataObjectRelationshipParserTest extends TestCase
         $this->assertEquals($name, $valid_relationships[0]);
     }
 
+    public function testValidNestedRelationshipIsReturned()
+    {
+        $name = 'FakeHasOneRelation.NullableFakeHasOneRelation';
+        $relationships = [$name];
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationships,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals($name, $valid_relationships[0]);
+    }
+
+    public function testValidNestedRelationshipWithSpacesIsReturned()
+    {
+        $expected = 'FakeHasOneRelation.NullableFakeHasOneRelation';
+        $name = ' FakeHasOneRelation . NullableFakeHasOneRelation ';
+        $relationships = [$name];
+        $valid_relationships = $this->relationship_parser->parseRelationshipsForDataObject(
+            $relationships,
+            ModelInstantiatorTestObject::class
+        );
+
+        $this->assertEquals(1, count($valid_relationships));
+        $this->assertEquals($expected, $valid_relationships[0]);
+    }
+
     public function testMultipleValidRelationshipsAreReturned()
     {
         $relationships = ['FakeHasOneRelation', 'NullableFakeHasOneRelation', 'FakeHasManyRelation'];
@@ -138,9 +165,28 @@ class DataObjectRelationshipParserTest extends TestCase
         }
     }
 
+    public function testInvalidNestedRelationshipThrowsException()
+    {
+        $name = "FakeHasOneRelation.invalid";
+        $relationships = [$name];
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationships,
+                ModelInstantiatorTestObject::class
+            );
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Unknown relationships - {$name}", $exception->getMessage());
+        }
+    }
+
     public function testMultipleInvalidRelationshipsAreIncludedInExceptionMessage()
     {
-        $name_1 = 'invalid1';
+        $name_1 = 'Invalid1';
         $name_2 = 'invalid2';
         $relationships = [$name_1, $name_2];
 

--- a/src/Parsers/DataObjectRelationshipParserTest.php
+++ b/src/Parsers/DataObjectRelationshipParserTest.php
@@ -157,6 +157,7 @@ class DataObjectRelationshipParserTest extends TestCase
                 $relationships,
                 ModelInstantiatorTestObject::class
             );
+
             $this->assertTrue(false, "Expected exception not thrown.");
         }
         catch(ValidationException $exception)
@@ -176,6 +177,7 @@ class DataObjectRelationshipParserTest extends TestCase
                 $relationships,
                 ModelInstantiatorTestObject::class
             );
+
             $this->assertTrue(false, "Expected exception not thrown.");
         }
         catch(ValidationException $exception)


### PR DESCRIPTION
Nested relationships can now be parsed and validated using dot syntax. 

For example: 
`parent.child.grandchild`

The convention is that each section of the relationship will be validated against the cardinalities of the specified data object. To be valid, the name specified must match the alias of a cardinality. That alias should match the name of the relationship defined on the data Model. 