### PR TITLE
Make nested circular relationship invalid.

### DIFF
--- a/src/Parsers/DataObjectRelationshipParser.php
+++ b/src/Parsers/DataObjectRelationshipParser.php
@@ -55,9 +55,7 @@ class DataObjectRelationshipParser
 
         if (!empty($invalid_relationships))
         {
-            $invalid_relationships_message = "Invalid relationships - " . implode(',', $invalid_relationships);
-
-            throw new ValidationException($invalid_relationships_message);
+            throw new ValidationException("Invalid relationships - " . implode(',', $invalid_relationships));
         }
 
         return $validated_relationships;

--- a/src/Parsers/DataObjectRelationshipParserTest.php
+++ b/src/Parsers/DataObjectRelationshipParserTest.php
@@ -162,7 +162,7 @@ class DataObjectRelationshipParserTest extends TestCase
         }
         catch(ValidationException $exception)
         {
-            $this->assertEquals("Unknown relationships - {$name}", $exception->getMessage());
+            $this->assertEquals("Invalid relationships - {$name}", $exception->getMessage());
         }
     }
 
@@ -182,7 +182,47 @@ class DataObjectRelationshipParserTest extends TestCase
         }
         catch(ValidationException $exception)
         {
-            $this->assertEquals("Unknown relationships - {$name}", $exception->getMessage());
+            $this->assertEquals("Invalid relationships - {$name}", $exception->getMessage());
+        }
+    }
+
+    public function testCircularNestedRelationshipThrowsException()
+    {
+        $name = "FakeHasOneRelation.NullableFakeHasOneRelation.FakeHasOneRelation";
+        $relationships = [$name];
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationships,
+                ModelInstantiatorTestObject::class
+            );
+
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Invalid relationships - {$name}", $exception->getMessage());
+        }
+    }
+
+    public function testCircularNestedRelationshipIsCaseInsensitiveAndThrowsException()
+    {
+        $name = "FakeHasOneRelation.NullableFakeHasOneRelation.fakehasonerelation";
+        $relationships = [$name];
+
+        try
+        {
+            $this->relationship_parser->parseRelationshipsForDataObject(
+                $relationships,
+                ModelInstantiatorTestObject::class
+            );
+
+            $this->assertTrue(false, "Expected exception not thrown.");
+        }
+        catch(ValidationException $exception)
+        {
+            $this->assertEquals("Invalid relationships - {$name}", $exception->getMessage());
         }
     }
 
@@ -203,7 +243,7 @@ class DataObjectRelationshipParserTest extends TestCase
         }
         catch(ValidationException $exception)
         {
-            $this->assertEquals("Unknown relationships - {$name_1},{$name_2}", $exception->getMessage());
+            $this->assertEquals("Invalid relationships - {$name_1},{$name_2}", $exception->getMessage());
         }
     }
 
@@ -223,7 +263,7 @@ class DataObjectRelationshipParserTest extends TestCase
         }
         catch(ValidationException $exception)
         {
-            $this->assertEquals("Unknown relationships - {$invalid}", $exception->getMessage());
+            $this->assertEquals("Invalid relationships - {$invalid}", $exception->getMessage());
         }
     }
 }


### PR DESCRIPTION
The goal with this change is to prevent requests for relationships that contain nested circular relationship from being considered valid. 

For example, `LiveRound.LiveScores.LiveRound` would technically be a valid relationship, but not one that we want to allow. 