### PR TITLE
If incoming property doesn't exist on data-object, throw an exception

### DIFF
--- a/src/Enforcers/Test/ValidationEnforcerTest.php
+++ b/src/Enforcers/Test/ValidationEnforcerTest.php
@@ -49,7 +49,7 @@ class ValidationEnforcerTest extends TestCase
             $this->assertTrue(true);
         } catch (ValidationListException $e) {
             $errors = json_encode($e->getErrors());
-            $this->assertStringContainsString('properties do not exist', $errors);
+            $this->assertStringContainsString('does not exist', $errors);
             $this->assertStringContainsString('nonExistentProperty', $errors);
         }
     }

--- a/src/Enforcers/Test/ValidationEnforcerTest.php
+++ b/src/Enforcers/Test/ValidationEnforcerTest.php
@@ -36,6 +36,25 @@ class ValidationEnforcerTest extends TestCase
         }
     }
 
+    public function testValidatesNonExistentPropertiesCorrectly(): void
+    {
+        $person = [
+            'email' => 'foo@bar.com',
+            'id' => 42,
+            'nonExistentProperty' => false
+        ];
+
+        try {
+            $this->enforcer->enforce($person, Person::class);
+            $this->assertTrue(true);
+        } catch (ValidationListException $e) {
+            $errors = json_encode($e->getErrors());
+            $this->assertStringContainsString('properties do not exist', $errors);
+            $this->assertStringContainsString('nonExistentProperty', $errors);
+        }
+    }
+
+
     public function testTypeValidatesCorrectly(): void
     {
         $person = ['email' => 1234, 'id' => 42];

--- a/src/Enforcers/ValidationEnforcer.php
+++ b/src/Enforcers/ValidationEnforcer.php
@@ -47,7 +47,8 @@ class ValidationEnforcer
 
         //For each property defined on the class.
         foreach ($metadata as $propName => $propMeta) {
-            // If the property is not included on the object, skip it.
+            // If the propName from the data-object is not included
+            // on the incoming object, don't attempt to validate it.
             if ($this->propIsUndefined($arr, $propName)) {
                 continue;
             }

--- a/src/Enforcers/ValidationEnforcer.php
+++ b/src/Enforcers/ValidationEnforcer.php
@@ -208,6 +208,6 @@ class ValidationEnforcer
      */
     private function getErrorMessage(string $propName): string
     {
-        return "These properties do not exist on the data object: '{$propName}'.";
+        return "'{$propName}' does not exist on the data-object.";
     }
 }

--- a/src/Enforcers/ValidationEnforcer.php
+++ b/src/Enforcers/ValidationEnforcer.php
@@ -36,9 +36,9 @@ class ValidationEnforcer
 
         // If an incoming property is not included on the
         // object, throw an error for stricter enforcement.
-        $nonExistantProperties = $this->checkForPropertiesNotOnDataObject($metadata, $arr);
+        $nonExistentProperties = $this->checkForPropertiesNotOnDataObject($metadata, $arr);
 
-        foreach ($nonExistantProperties as $badProperty) {
+        foreach ($nonExistentProperties as $badProperty) {
             $validationErrors->addError(
                 $this->getErrorMessage($badProperty),
                 $badProperty,

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -100,7 +100,7 @@ class ModelInstantiatorTest extends TestCase
 
             $this->assertTrue(true);
         } catch (ValidationListException $e) {
-            $this->assertStringContainsString('properties do not exist', json_encode($e->getErrors()));
+            $this->assertStringContainsString('does not exist', json_encode($e->getErrors()));
         }
     }
 


### PR DESCRIPTION
ON HOLD. This is a good idea because it will help reduce issues because of misspelled or unavailable prop names, but it affects Point In Time / Leaderboard export and some existing tests that will need to first be updated in PHP-API before it can be used there. 