### PR TITLE
Merging develop into main for 5.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+### 5.3.0
+* Created the IPrivacyProtectedDataObjectInterface. This interface will be implemented by data objects that need to have privacy protected data cleansed when the data object is converted to an array.
+
 ### 5.2.0
 * Code styling fixes.
 
 ### 5.1.0
-* Adds `JsonConverter` for database columns storying json data to have it automatically converted to php arrays.
+* Adds `JsonConverter` for database columns storing json data to have it automatically converted to php arrays.
 
 ### 5.0.0
 * _BREAKING_: `DataObjectRelationshipParser` no longer supports nested circular relationships. These will now be considered invalid and will throw a `ValidationException`.

--- a/src/Interfaces/IPrivacyProtectedDataObject.php
+++ b/src/Interfaces/IPrivacyProtectedDataObject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PDGA\DataObjects\Interfaces;
+
+interface IPrivacyProtectedDataObject
+{
+
+    /**
+     * This will be implemented by any data object that needs to have the values for
+     * privacy protected fields removed. The implementation of this method for the
+     * data object should unset the values of the protected fields.
+     *
+     * @return void
+     */
+    public function cleansePrivacyProtectedFields(): void;
+}

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -5,6 +5,7 @@ namespace PDGA\DataObjects\Models;
 use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Enforcers\ValidationEnforcer;
 use PDGA\DataObjects\Interfaces\IDatabaseModel;
+use PDGA\DataObjects\Interfaces\IPrivacyProtectedDataObject;
 use PDGA\DataObjects\Models\ReflectionContainer;
 use PDGA\Exception\InvalidRelationshipDataException;
 use PDGA\Exception\ValidationException;
@@ -230,9 +231,10 @@ class ModelInstantiator
 
     /**
      * Converts a Data Object instance to an array.
+     * If a data object is an instance of IPrivacyProtectedDataObject,
+     * the method to cleanse the privacy related fields will be called on that object.
      *
      * @param object $data_object An instance of a hydrated Data Object.
-     *
      * @return array
      */
     public function dataObjectToArray(
@@ -247,6 +249,11 @@ class ModelInstantiator
 
             if ($data_obj instanceof DateTime) {
                 return $data_obj->format(DateTime::ATOM);
+            }
+
+            // This will cleanse any private data from the data object if necessary.
+            if ($data_obj instanceof IPrivacyProtectedDataObject) {
+                $data_obj->cleansePrivacyProtectedFields();
             }
 
             // $data_obj is an array or object.  Cast to array, then cast each

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -4,6 +4,8 @@ namespace PDGA\DataObjects\Models\Test;
 
 use \DateTime;
 
+use PDGA\DataObjects\Models\Test\ModelInstantiatorTestObject;
+use PDGA\DataObjects\Models\Test\PrivacyProtectedTestDataObject;
 use PHPUnit\Framework\TestCase;
 
 use PDGA\Exception\InvalidRelationshipDataException;
@@ -14,7 +16,6 @@ use PDGA\DataObjects\Models\ModelInstantiator;
 use PDGA\DataObjects\Models\ReflectionContainer;
 use PDGA\DataObjects\Models\Test\Member;
 use PDGA\DataObjects\Models\Test\ModelInstantiatorTestDBModel;
-use PDGA\DataObjects\Models\Test\ModelInstantiatorTestObject;
 use PDGA\DataObjects\Models\Test\PhoneNumber;
 
 class ModelInstantiatorTest extends TestCase
@@ -282,6 +283,8 @@ class ModelInstantiatorTest extends TestCase
 
         // The output array should reflect the Data Object properties.
         // Note that the order of the array keys matters and must match the class definition.
+        $result = $this->model_instantiator->dataObjectToArray($data_object);
+
         $this->assertSame(
             [
                 'pdgaNumber'   => 4297,
@@ -292,7 +295,86 @@ class ModelInstantiatorTest extends TestCase
                 'birthDate'    => '2020-01-01T00:00:00+00:00',
                 'testProperty' => true,
             ],
-            $this->model_instantiator->dataObjectToArray($data_object)
+            $result
+        );
+    }
+
+    public function testDataObjectToArrayWithPrivacyProtectedDataObject(): void
+    {
+        // Create an input Privacy Protected Data Object instance.
+        $data_object = $this->getPrivacyProtectedTestDataObject();
+
+        // Assert that the privacy protected properties are set prior to array conversion.
+        $this->assertPrivacyProtectedPropertiesAreSet($data_object);
+
+        // The output array should reflect the Data Object properties.
+        // The values for the privacy protected fields should be removed.
+        $result = $this->model_instantiator->dataObjectToArray($data_object);
+
+        $this->assertSame(
+            [
+                'pdgaNumber'   => 4297,
+                'firstName'    => 'Ken',
+                'lastName'     => 'Climo',
+                'testProperty' => true,
+            ],
+            $result
+        );
+
+        foreach (PrivacyProtectedTestDataObject::PRIVACY_PROTECTED_PROPERTIES as $property) {
+            $this->assertFalse(isset($result[$property]));
+        }
+    }
+
+    public function testNestedDataObjectToArrayWithPrivacyProtectedDataObject(): void
+    {
+        // Create a related Privacy Protected Data Object instance.
+        $fake_has_one_data_object = $this->getPrivacyProtectedTestDataObject();
+        $nullable_fake_has_one_data_object = $this->getPrivacyProtectedTestDataObject();
+        $fake_has_many_data_object = [$this->getPrivacyProtectedTestDataObject()];
+
+        // Create the primary data object and set relationship values.
+        $data_object = $this->getPrivacyProtectedTestDataObject();
+        $data_object->fakeHasOneRelation = $fake_has_one_data_object;
+        $data_object->nullableFakeHasOneRelation = $nullable_fake_has_one_data_object;
+        $data_object->fakeHasManyRelation = $fake_has_many_data_object;
+
+        // Assert that the privacy protected properties are set prior to array conversion.
+        $this->assertPrivacyProtectedPropertiesAreSet($data_object);
+        $this->assertPrivacyProtectedPropertiesAreSet($fake_has_one_data_object);
+        $this->assertPrivacyProtectedPropertiesAreSet($nullable_fake_has_one_data_object);
+        $this->assertPrivacyProtectedPropertiesAreSet($fake_has_many_data_object[0]);
+
+        // The output array should reflect the Data Object properties.
+        // The values for the privacy protected fields should be removed.
+        $result = $this->model_instantiator->dataObjectToArray($data_object);
+
+        $this->assertSame(
+            [
+                'pdgaNumber'   => 4297,
+                'firstName'    => 'Ken',
+                'lastName'     => 'Climo',
+                'testProperty' => true,
+                'fakeHasOneRelation' => [
+                    'pdgaNumber'   => 4297,
+                    'firstName'    => 'Ken',
+                    'lastName'     => 'Climo',
+                    'testProperty' => true,
+                ],
+                'nullableFakeHasOneRelation' => [
+                    'pdgaNumber'   => 4297,
+                    'firstName'    => 'Ken',
+                    'lastName'     => 'Climo',
+                    'testProperty' => true,
+                ],
+                'fakeHasManyRelation' => [[
+                    'pdgaNumber'   => 4297,
+                    'firstName'    => 'Ken',
+                    'lastName'     => 'Climo',
+                    'testProperty' => true,
+                ]],
+            ],
+            $result
         );
     }
 
@@ -477,6 +559,31 @@ class ModelInstantiatorTest extends TestCase
             $this->assertTrue(false);
         } catch (InvalidRelationshipDataException $e) {
             $this->assertEquals('FakeHasOneRelation relationship must not be null.', $e->getMessage());
+        }
+    }
+
+    /**
+     * @return PrivacyProtectedTestDataObject
+     */
+    private function getPrivacyProtectedTestDataObject(): PrivacyProtectedTestDataObject
+    {
+        // Create an input Privacy Protected Data Object instance.
+        $data_object = new PrivacyProtectedTestDataObject();
+        $data_object->firstName = 'Ken';
+        $data_object->lastName = 'Climo';
+        $data_object->pdgaNumber = 4297;
+        $data_object->email = 'champ@pdga.com';
+        $data_object->privacy = true;
+        $data_object->testProperty = true;
+        $data_object->birthDate = new DateTime('2020-01-01');
+
+        return $data_object;
+    }
+
+    private function assertPrivacyProtectedPropertiesAreSet(PrivacyProtectedTestDataObject $data_object): void
+    {
+        foreach (PrivacyProtectedTestDataObject::PRIVACY_PROTECTED_PROPERTIES as $property) {
+            $this->assertTrue(isset($data_object->$property));
         }
     }
 }

--- a/src/Models/Test/PrivacyProtectedTestDataObject.php
+++ b/src/Models/Test/PrivacyProtectedTestDataObject.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PDGA\DataObjects\Models\Test;
+
+use \DateTime;
+
+use PDGA\DataObjects\Attributes\Column;
+use PDGA\DataObjects\Attributes\ManyToOne;
+use PDGA\DataObjects\Attributes\OneToMany;
+use PDGA\DataObjects\Attributes\Table;
+use PDGA\DataObjects\Converters\YesNoConverter;
+use PDGA\DataObjects\Converters\DateTimeConverter;
+use PDGA\DataObjects\Interfaces\IPrivacyProtectedDataObject;
+
+/**
+ * Placeholder class.
+ */
+#[Table]
+class PrivacyProtectedTestDataObject implements IPrivacyProtectedDataObject
+{
+    const PRIVACY_PROTECTED_PROPERTIES = [
+        'email',
+        'birthDate',
+        'privacy',
+    ];
+
+    #[Column(
+        name: 'PDGANum',
+        sqlDataType: 'int',
+    )]
+    public ?int $pdgaNumber;
+
+    #[Column(
+        name: 'FirstName',
+        sqlDataType: 'varchar',
+    )]
+    public ?string $firstName;
+
+    #[Column(
+        name: 'LastName',
+        sqlDataType: 'varchar',
+    )]
+    public ?string $lastName;
+
+    #[Column(
+        name: 'Email',
+        sqlDataType: 'varchar',
+    )]
+    public ?string $email;
+
+    #[Column(
+        name: 'Privacy',
+        sqlDataType: 'enum',
+        converter: new YesNoConverter(),
+    )]
+    public ?bool $privacy;
+
+    #[Column(
+        name: 'BirthDate',
+        sqlDataType: 'date',
+        converter: new DateTimeConverter(),
+    )]
+    public ?DateTime $birthDate;
+
+    /**
+     * Used to test properties without a Column attribute.
+     *
+     * @var bool
+     */
+    public bool $testProperty = false;
+
+    // Used to test ManyToOne relations.
+    #[ManyToOne(
+        PrivacyProtectedTestDataObject::class,
+        'FakeHasOneRelation',
+    )]
+    public PrivacyProtectedTestDataObject $fakeHasOneRelation;
+
+    // Used to test nullable ManyToOne relations.
+    #[ManyToOne(
+        PrivacyProtectedTestDataObject::class,
+        'NullableFakeHasOneRelation',
+    )]
+    public ?PrivacyProtectedTestDataObject $nullableFakeHasOneRelation;
+
+    // Used to test OneToMany relations.
+    #[OneToMany(
+        PrivacyProtectedTestDataObject::class,
+        'FakeHasManyRelation',
+    )]
+    public array $fakeHasManyRelation;
+
+    public function cleansePrivacyProtectedFields(): void
+    {
+        // Unsets the values for the privacy protected properties
+        if (isset($this->privacy) && $this->privacy) {
+            foreach (self::PRIVACY_PROTECTED_PROPERTIES as $property) {
+                unset($this->$property);
+            }
+        }
+    }
+}


### PR DESCRIPTION
These are the changes to support the new `IPrivacyProtectedDataObjectInterface` interface that allows data objects to implement a method that cleanses privacy protected fields when converted to an array.  