### PR TITLE
updated `dataObjectToArray` to accept an override boolean for preventing privacy protected cleansing

### DIFF
--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -9,7 +9,6 @@ use PDGA\DataObjects\Interfaces\IPrivacyProtectedDataObject;
 use PDGA\DataObjects\Models\ReflectionContainer;
 use PDGA\Exception\InvalidRelationshipDataException;
 use PDGA\Exception\ValidationException;
-
 use \Datetime;
 use ReflectionException;
 
@@ -235,14 +234,18 @@ class ModelInstantiator
      * the method to cleanse the privacy related fields will be called on that object.
      *
      * @param object $data_object An instance of a hydrated Data Object.
+     * @param bool $cleanse_privacy Defaults to allowing if data object
+     *                              implements contract, but can be overridden
+     *                              so no cleansing is done, eg for internal use.
      * @return array
      */
     public function dataObjectToArray(
-        object $data_object
+        object $data_object,
+        bool $cleanse_privacy = true,
     ): array {
         // Internal driver function that recursively converts an object to an
         // array and accepts a mixed-type argument.
-        $to_array = function (mixed $data_obj) use (&$to_array) {
+        $to_array = function (mixed $data_obj) use (&$to_array, $cleanse_privacy) {
             if (is_null($data_obj) || is_scalar($data_obj)) {
                 return $data_obj;
             }
@@ -252,7 +255,7 @@ class ModelInstantiator
             }
 
             // This will cleanse any private data from the data object if necessary.
-            if ($data_obj instanceof IPrivacyProtectedDataObject) {
+            if ($data_obj instanceof IPrivacyProtectedDataObject && $cleanse_privacy === true) {
                 $data_obj->cleansePrivacyProtectedFields();
             }
 

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -326,6 +326,37 @@ class ModelInstantiatorTest extends TestCase
         }
     }
 
+    public function testDataObjectToArrayWithPrivacyProtectedDataObjectButAlsoOverridden(): void
+    {
+        // Create an input Data Object instance.
+        $data_object               = new ModelInstantiatorTestObject();
+        $data_object->firstName    = 'Ken';
+        $data_object->lastName     = 'Climo';
+        $data_object->pdgaNumber   = 4297;
+        $data_object->email        = 'champ@pdga.com';
+        $data_object->privacy      = true;
+        $data_object->testProperty = true;
+        $data_object->birthDate    = new DateTime('2020-01-01');
+
+        // The output array should reflect the Data Object properties.
+        // Note that the order of the array keys matters and must match the class definition.
+        $cleanse_privacy = false;
+        $result = $this->model_instantiator->dataObjectToArray($data_object, $cleanse_privacy);
+
+        $this->assertSame(
+            [
+                'pdgaNumber'   => 4297,
+                'firstName'    => 'Ken',
+                'lastName'     => 'Climo',
+                'email'        => 'champ@pdga.com',
+                'privacy'      => true,
+                'birthDate'    => '2020-01-01T00:00:00+00:00',
+                'testProperty' => true,
+            ],
+            $result
+        );
+    }
+
     public function testNestedDataObjectToArrayWithPrivacyProtectedDataObject(): void
     {
         // Create a related Privacy Protected Data Object instance.


### PR DESCRIPTION
Purpose is to allow the need for an authorized user to see privacy-protected fields by allowing the passing in of `false` so that the privacy cleansing will be skipped.