### PR TITLE
Allow model instantiator relationship nulls

### DIFF
--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -347,7 +347,7 @@ class ModelInstantiator
         $reflection_index = array_search($property, array_column($property_reflection, 'name'), true);
 
         if (false === $reflection_index || !isset($property_reflection[$reflection_index])) {
-            throw new OutOfBoundsException();
+            throw new OutOfBoundsException("The property {$property} does not exist in property reflection.");
         }
 
         return $property_reflection[$reflection_index];

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -83,7 +83,7 @@ class ModelInstantiator
             } else {
                 // ManyToOne: Map to a single nested Data Object.
 
-                if (is_null($arr[$property]) && $this->propertyAllowsNull($property, $property_reflection)) {
+                if ($enforcer->propIsNull($arr, $property) && $this->propertyAllowsNull($property, $property_reflection)) {
                     $instance->{$property} = null;
                     continue;
                 }
@@ -331,23 +331,30 @@ class ModelInstantiator
     }
 
     /**
-     * @param mixed $property
+     * Public for testability.
+     * @param string $property ReflectionProperties->getName() always returns a string which is the key of the array that handles this property
      * @param array $property_reflection
-     * @return mixed
+     * @return \ReflectionProperty
+     * @throws \TypeError
      */
-    private function getReflectionProperty(mixed $property, array $property_reflection): mixed
+    public function getReflectionProperty(string $property, array $property_reflection): \ReflectionProperty
     {
-        $reflection_index = array_search($property, array_column($property_reflection, 'name'));
+        $reflection_index = array_search($property, array_column($property_reflection, 'name'), true);
+
+        if (false === $reflection_index || !isset($property_reflection[$reflection_index])) {
+            throw new \TypeError();
+        }
 
         return $property_reflection[$reflection_index];
     }
 
     /**
-     * @param mixed $property
+     * Public for testability.
+     * @param string $property ReflectionProperties->getName() always returns a string which is the key of the array that handles this property
      * @param array $property_reflection
      * @return bool
      */
-    private function propertyAllowsNull(mixed $property, array $property_reflection): bool
+    public function propertyAllowsNull(string $property, array $property_reflection): bool
     {
         $reflection_property = $this->getReflectionProperty($property, $property_reflection);
 

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -2,6 +2,7 @@
 
 namespace PDGA\DataObjects\Models;
 
+use OutOfBoundsException;
 use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Enforcers\ValidationEnforcer;
 use PDGA\DataObjects\Interfaces\IDatabaseModel;
@@ -10,6 +11,7 @@ use PDGA\Exception\InvalidRelationshipDataException;
 use PDGA\Exception\ValidationException;
 use \Datetime;
 use ReflectionException;
+use ReflectionProperty;
 
 class ModelInstantiator
 {
@@ -337,15 +339,15 @@ class ModelInstantiator
      *                         a string which is the key of the array that
      *                         handles this property.
      * @param array $property_reflection
-     * @return \ReflectionProperty
-     * @throws \TypeError
+     * @return ReflectionProperty
+     * @throws OutOfBoundsException
      */
-    public function getReflectionProperty(string $property, array $property_reflection): \ReflectionProperty
+    public function getReflectionProperty(string $property, array $property_reflection): ReflectionProperty
     {
         $reflection_index = array_search($property, array_column($property_reflection, 'name'), true);
 
         if (false === $reflection_index || !isset($property_reflection[$reflection_index])) {
-            throw new \TypeError();
+            throw new OutOfBoundsException();
         }
 
         return $property_reflection[$reflection_index];

--- a/src/Models/ModelInstantiator.php
+++ b/src/Models/ModelInstantiator.php
@@ -83,7 +83,8 @@ class ModelInstantiator
             } else {
                 // ManyToOne: Map to a single nested Data Object.
 
-                if ($enforcer->propIsNull($arr, $property) && $this->propertyAllowsNull($property, $property_reflection)) {
+                if ($enforcer->propIsNull($arr, $property) &&
+                    $this->propertyAllowsNull($property, $property_reflection)) {
                     $instance->{$property} = null;
                     continue;
                 }
@@ -332,7 +333,9 @@ class ModelInstantiator
 
     /**
      * Public for testability.
-     * @param string $property ReflectionProperties->getName() always returns a string which is the key of the array that handles this property
+     * @param string $property ReflectionProperties->getName() always returns
+     *                         a string which is the key of the array that
+     *                         handles this property.
      * @param array $property_reflection
      * @return \ReflectionProperty
      * @throws \TypeError
@@ -350,7 +353,9 @@ class ModelInstantiator
 
     /**
      * Public for testability.
-     * @param string $property ReflectionProperties->getName() always returns a string which is the key of the array that handles this property
+     * @param string $property ReflectionProperties->getName() always returns
+     * *                         a string which is the key of the array that
+     * *                         handles this property.
      * @param array $property_reflection
      * @return bool
      */

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -685,7 +685,11 @@ class ModelInstantiatorTest extends TestCase
         // Search to make sure the property exists in the data object or we'll get a false
         // positive for this test.
         $found = array_search($property, array_column($property_reflection, 'name'));
-        $this->assertGreaterThan(0, $found, "The {$property} was not found; check that the test is reflects a property that exists.");
+        $this->assertGreaterThan(
+            0,
+            $found,
+            "The {$property} was not found; check that the test is reflects a property that exists.",
+        );
 
         $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
         $this->assertTrue($result);
@@ -705,7 +709,11 @@ class ModelInstantiatorTest extends TestCase
         // Search to make sure the property exists in the data object or we'll get a false
         // positive for this test.
         $found = array_search($property, array_column($property_reflection, 'name'), true);
-        $this->assertGreaterThan(0, $found, "The {$property} was not found; check that the test is reflects a property that exists.");
+        $this->assertGreaterThan(
+            0,
+            $found,
+            "The {$property} was not found; check that the test is reflects a property that exists.",
+        );
 
         $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
         $this->assertFalse($result);

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -156,6 +156,55 @@ class ModelInstantiatorTest extends TestCase
         }
     }
 
+    /**
+     * Validates that relationships can be null if defined that way
+     * in the data object.
+     * @throws ValidationException
+     */
+    public function testArrayToDataObjectPermitsNullableRelationsWhenDefinedNullable(): void
+    {
+        $fake_has_one_data_object = $this->getTestDataObject();
+        $fake_has_many_data_object = [$this->getTestDataObject()];
+
+        $data_object = $this->getTestDataObject();
+        $data_object->fakeHasOneRelation = $fake_has_one_data_object;
+        $data_object->nullableFakeHasOneRelation = null;
+        $data_object->fakeHasManyRelation = $fake_has_many_data_object;
+
+        $fake_relationship_array = [
+            'pdgaNumber' => 4297,
+            'firstName' => 'Ken',
+            'lastName' => 'Climo',
+            'testProperty' => true,
+            'email' => 'champ@pdga.com',
+            'privacy' => true,
+            'birthDate' => '2020-01-01T00:00:00+00:00',
+        ];
+
+        $array = [
+            'pdgaNumber' => 4297,
+            'firstName' => 'Ken',
+            'lastName' => 'Climo',
+            'testProperty' => true,
+            'email' => 'champ@pdga.com',
+            'privacy' => true,
+            'birthDate' => '2020-01-01T00:00:00+00:00',
+            'fakeHasOneRelation' => $fake_relationship_array,
+            'nullableFakeHasOneRelation' => null,
+            'fakeHasManyRelation' => [$fake_relationship_array],
+        ];
+
+        $actual = $this->model_instantiator->arrayToDataObject(
+            $array,
+            ModelInstantiatorTestObject::class,
+        );
+
+        $this->assertEquals(
+            $data_object,
+            $actual
+        );
+    }
+
     public function testDataObjectToDatabaseModel(): void
     {
         // Create an input Data Object with all Column properties set.
@@ -600,6 +649,20 @@ class ModelInstantiatorTest extends TestCase
     {
         // Create an input Privacy Protected Data Object instance.
         $data_object = new PrivacyProtectedTestDataObject();
+        $data_object->firstName = 'Ken';
+        $data_object->lastName = 'Climo';
+        $data_object->pdgaNumber = 4297;
+        $data_object->email = 'champ@pdga.com';
+        $data_object->privacy = true;
+        $data_object->testProperty = true;
+        $data_object->birthDate = new DateTime('2020-01-01');
+
+        return $data_object;
+    }
+
+    private function getTestDataObject(): ModelInstantiatorTestObject
+    {
+        $data_object = new ModelInstantiatorTestObject();
         $data_object->firstName = 'Ken';
         $data_object->lastName = 'Climo';
         $data_object->pdgaNumber = 4297;

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -4,6 +4,7 @@ namespace PDGA\DataObjects\Models\Test;
 
 use \DateTime;
 
+use OutOfBoundsException;
 use PDGA\DataObjects\Models\Test\ModelInstantiatorTestObject;
 use PDGA\DataObjects\Models\Test\PrivacyProtectedTestDataObject;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ use PDGA\DataObjects\Models\Test\Member;
 use PDGA\DataObjects\Models\Test\ModelInstantiatorTestDBModel;
 use PDGA\DataObjects\Models\Test\PhoneNumber;
 use ReflectionClass;
+use ReflectionProperty;
 
 class ModelInstantiatorTest extends TestCase
 {
@@ -683,10 +685,10 @@ class ModelInstantiatorTest extends TestCase
         // Search to make sure the property exists in the data object or we'll get a false
         // positive for this test.
         $found = array_search($property, array_column($property_reflection, 'name'));
-        $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
+        $this->assertGreaterThan(0, $found, "The {$property} was not found; check that the test is reflects a property that exists.");
 
+        $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
         $this->assertTrue($result);
-        $this->assertGreaterThan(0, $found);
     }
 
     /**
@@ -703,10 +705,10 @@ class ModelInstantiatorTest extends TestCase
         // Search to make sure the property exists in the data object or we'll get a false
         // positive for this test.
         $found = array_search($property, array_column($property_reflection, 'name'), true);
-        $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
+        $this->assertGreaterThan(0, $found, "The {$property} was not found; check that the test is reflects a property that exists.");
 
+        $result = $this->model_instantiator->propertyAllowsNull($property, $property_reflection);
         $this->assertFalse($result);
-        $this->assertGreaterThan(0, $found);
     }
 
     public function testGetReflectionPropertyCorrectlyReturnsReflectionPropertyObject()
@@ -717,7 +719,7 @@ class ModelInstantiatorTest extends TestCase
 
         $result = $this->model_instantiator->getReflectionProperty($property, $property_reflection);
 
-        $this->assertInstanceOf(\ReflectionProperty::class, $result);
+        $this->assertInstanceOf(ReflectionProperty::class, $result);
     }
 
     public function testGetReflectionPropertyCorrectlyReturnsFalseIfNotFound()
@@ -726,7 +728,7 @@ class ModelInstantiatorTest extends TestCase
         $property_reflection = $reflection_class->getProperties();
         $property = 'zzz__does_not_exist'; // this property should not exist on the test data object
 
-        $this->expectException(\TypeError::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $this->model_instantiator->getReflectionProperty($property, $property_reflection);
     }

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -727,7 +727,8 @@ class ModelInstantiatorTest extends TestCase
 
         $result = $this->model_instantiator->getReflectionProperty($property, $property_reflection);
 
-        $this->assertInstanceOf(ReflectionProperty::class, $result);
+        $this->assertEquals($property, $result->getName());
+        $this->assertEquals(ModelInstantiatorTestObject::class, $result->getDeclaringClass()->getName());
     }
 
     public function testGetReflectionPropertyCorrectlyReturnsFalseIfNotFound()


### PR DESCRIPTION
Previously arrayToDataObject didn't allow a relationship to be null, even if the data object declared it nullable.

Note: _I originally branched from `main` thinking this repo was one that branched from `main` but afterwards pulled in `develop` into this branch, which brought in two commits._

