### PR TITLE
Adding converter that converts empty strings to null.

### DIFF
--- a/src/Converters/EmptyStringToNullConverter.php
+++ b/src/Converters/EmptyStringToNullConverter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PDGA\DataObjects\Converters;
+
+/**
+ * Converts empty strings into null values.
+ * This should be used with nullable string data object properties.
+ */
+class EmptyStringToNullConverter implements Converter
+{
+    public function onRetrieve(mixed $val): mixed
+    {
+        return $this->convertEmptyStringToNull($val);
+    }
+
+    public function onSave(mixed $val): mixed
+    {
+        return $this->convertEmptyStringToNull($val);
+    }
+
+    private function convertEmptyStringToNull($val): ?string
+    {
+        return $val != '' ? $val : null;
+    }
+}

--- a/src/Converters/Test/EmptyStringToNullConverterTest.php
+++ b/src/Converters/Test/EmptyStringToNullConverterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PDGA\DataObjects\Converters\Test;
+
+use PDGA\DataObjects\Converters\EmptyStringToNullConverter;
+use PHPUnit\Framework\TestCase;
+
+class EmptyStringToNullConverterTest extends TestCase
+{
+    private EmptyStringToNullConverter $converter;
+
+    public function setUp(): void
+    {
+        $this->converter = new EmptyStringToNullConverter();
+    }
+
+    public function testOnRetrieveEmptyIsConvertedToNull()
+    {
+        $empty = '';
+
+        $result = $this->converter->onRetrieve($empty);
+
+        $this->assertNull($result);
+    }
+
+    public function testOnRetrieveNullReturnsNull()
+    {
+        $value = null;
+
+        $result = $this->converter->onRetrieve($value);
+
+        $this->assertNull($result);
+    }
+
+    public function testOnRetrieveNonEmptyStringReturnsString()
+    {
+        $value = 'test';
+
+        $result = $this->converter->onRetrieve($value);
+
+        $this->assertEquals($value, $result);
+    }
+
+    public function testOnSaveEmptyIsConvertedToNull()
+    {
+        $empty = '';
+
+        $result = $this->converter->onSave($empty);
+
+        $this->assertNull($result);
+    }
+
+    public function testOnSaveNullReturnsNull()
+    {
+        $value = null;
+
+        $result = $this->converter->onSave($value);
+
+        $this->assertNull($result);
+    }
+
+    public function testOnSaveNonEmptyStringReturnsString()
+    {
+        $value = 'test';
+
+        $result = $this->converter->onSave($value);
+
+        $this->assertEquals($value, $result);
+    }
+}

--- a/src/Models/Test/ModelInstantiatorTest.php
+++ b/src/Models/Test/ModelInstantiatorTest.php
@@ -547,8 +547,7 @@ class ModelInstantiatorTest extends TestCase
         );
 
         // This uses the empty string to null conversion
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $this->model_instantiator->convertPropertyOnSave(
                 $columns['displayName'],
                 $data_object->displayName,
@@ -607,8 +606,7 @@ class ModelInstantiatorTest extends TestCase
         );
 
         // This uses the empty string to null conversion
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $this->model_instantiator->convertPropertyOnRetrieve(
                 $columns['displayName'],
                 $db_model['DisplayName'],

--- a/src/Models/Test/ModelInstantiatorTestDBModel.php
+++ b/src/Models/Test/ModelInstantiatorTestDBModel.php
@@ -10,9 +10,10 @@ class ModelInstantiatorTestDBModel implements IDatabaseModel
     private $attributes = [];
     private $relations  = [];
 
-    public function __construct(int $pdga_num)
+    public function __construct(int $pdga_num, ?string $display_name = null)
     {
         $this->attributes['PDGANum'] = $pdga_num;
+        $this->attributes['DisplayName'] = $display_name;
     }
 
     public function getAttributes(): array

--- a/src/Models/Test/ModelInstantiatorTestObject.php
+++ b/src/Models/Test/ModelInstantiatorTestObject.php
@@ -8,6 +8,7 @@ use PDGA\DataObjects\Attributes\Column;
 use PDGA\DataObjects\Attributes\ManyToOne;
 use PDGA\DataObjects\Attributes\OneToMany;
 use PDGA\DataObjects\Attributes\Table;
+use PDGA\DataObjects\Converters\EmptyStringToNullConverter;
 use PDGA\DataObjects\Converters\YesNoConverter;
 use PDGA\DataObjects\Converters\DateTimeConverter;
 
@@ -34,6 +35,13 @@ class ModelInstantiatorTestObject
         sqlDataType: 'varchar',
     )]
     public ?string $lastName;
+
+    #[Column(
+        name: 'DisplayName',
+        sqlDataType: 'varchar',
+        converter: new EmptyStringToNullConverter()
+    )]
+    public ?string $displayName;
 
     #[Column(
         name: 'Email',

--- a/src/Models/Test/ReflectionContainerTest.php
+++ b/src/Models/Test/ReflectionContainerTest.php
@@ -32,6 +32,7 @@ class ReflectionContainerTest extends TestCase
                 'pdgaNumber',
                 'firstName',
                 'lastName',
+                'displayName',
                 'email',
                 'privacy',
                 'birthDate',


### PR DESCRIPTION
https://pdga.atlassian.net/browse/PDGA-681

This adds a new converter that will translate empty strings to null. This will occur whenever the conversions occur.  The impacted `ModelInstantiator` methods are:
- `databaseModelToDataObject`
- `dataObjectToDatabaseModel`

The situation that brought this need to light was identified in the above issue. We were attempting to read a record out of the database that had an empty string value for one of the properties and then submit that object for an update. When this happened the validation enforcement failed. 

With this change, when that occurs, those empty string values will automatically be converted to `null` instead. This should work fine assuming that the property itself is nullable. 

This converter should only be applied to nullable properties. An exception will be thrown if `null` is attempted to be assigned to a non-nullable property. 